### PR TITLE
Add Virtual Folder support

### DIFF
--- a/src/AzureStorageWrapper/.idea/.idea.AzureStorageWrapper/.idea/encodings.xml
+++ b/src/AzureStorageWrapper/.idea/.idea.AzureStorageWrapper/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/src/AzureStorageWrapper/.idea/.idea.AzureStorageWrapper/.idea/indexLayout.xml
+++ b/src/AzureStorageWrapper/.idea/.idea.AzureStorageWrapper/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/src/AzureStorageWrapper/.idea/.idea.AzureStorageWrapper/.idea/projectSettingsUpdater.xml
+++ b/src/AzureStorageWrapper/.idea/.idea.AzureStorageWrapper/.idea/projectSettingsUpdater.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RiderProjectSettingsUpdater">
+    <option name="vcsConfiguration" value="2" />
+  </component>
+</project>

--- a/src/AzureStorageWrapper/.idea/.idea.AzureStorageWrapper/.idea/vcs.xml
+++ b/src/AzureStorageWrapper/.idea/.idea.AzureStorageWrapper/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+  </component>
+</project>

--- a/src/AzureStorageWrapper/.idea/.idea.AzureStorageWrapper/.idea/workspace.xml
+++ b/src/AzureStorageWrapper/.idea/.idea.AzureStorageWrapper/.idea/workspace.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="539293f7-f728-4cb5-b249-974721107f91" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/AzureStorageWrapper.Tests/Should/UriShould.cs" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/AzureStorageWrapper/IUriService.cs" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/AzureStorageWrapper/UriService.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/AzureStorageWrapper/AzureStorageWrapper.cs" beforeDir="false" afterPath="$PROJECT_DIR$/AzureStorageWrapper/AzureStorageWrapper.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/AzureStorageWrapper/Commands/GetSasUri.cs" beforeDir="false" afterPath="$PROJECT_DIR$/AzureStorageWrapper/Commands/GetSasUri.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/AzureStorageWrapper/Commands/UploadBlob.cs" beforeDir="false" afterPath="$PROJECT_DIR$/AzureStorageWrapper/Commands/UploadBlob.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/AzureStorageWrapper/DependencyInjectionExtension.cs" beforeDir="false" afterPath="$PROJECT_DIR$/AzureStorageWrapper/DependencyInjectionExtension.cs" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_BRANCH_BY_REPOSITORY">
+      <map>
+        <entry key="$PROJECT_DIR$/../.." value="dev" />
+      </map>
+    </option>
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$/../.." />
+  </component>
+  <component name="HighlightingSettingsPerFile">
+    <setting file="file://$USER_HOME$/AppData/Local/Symbols/src/Azure/azure-sdk-for-net/6ceae18442793de1d7c49657289772fac034d99e/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs" root0="SKIP_HIGHLIGHTING" />
+  </component>
+  <component name="MetaFilesCheckinStateConfiguration" checkMetaFiles="true" />
+  <component name="ProjectColorInfo">{
+  &quot;customColor&quot;: &quot;&quot;,
+  &quot;associatedIndex&quot;: 7
+}</component>
+  <component name="ProjectId" id="2ZfZhQ7e4yBO02v3Wlp3ItvqO7U" />
+  <component name="ProjectLevelVcsManager">
+    <ConfirmationsSetting value="2" id="Add" />
+  </component>
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "git-widget-placeholder": "features/virtual__folder__support",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "CodeLensConfigurable",
+    "vue.rearranger.settings.migration": "true"
+  },
+  "keyToStringList": {
+    "rider.external.source.directories": [
+      "C:\\Users\\sergio\\AppData\\Roaming\\JetBrains\\Rider2023.3\\resharper-host\\DecompilerCache",
+      "C:\\Users\\sergio\\AppData\\Roaming\\JetBrains\\Rider2023.3\\resharper-host\\SourcesCache",
+      "C:\\Users\\sergio\\AppData\\Local\\Symbols\\src"
+    ]
+  }
+}]]></component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="539293f7-f728-4cb5-b249-974721107f91" name="Changes" comment="" />
+      <created>1702815214793</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1702815214793</updated>
+      <workItem from="1702815217481" duration="2208000" />
+      <workItem from="1702823615309" duration="2472000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="UnityCheckinConfiguration" checkUnsavedScenes="true" />
+  <component name="VcsManagerConfiguration">
+    <option name="CLEAR_INITIAL_COMMIT_MESSAGE" value="true" />
+  </component>
+  <component name="XSLT-Support.FileAssociations.UIState">
+    <expand />
+    <select />
+  </component>
+</project>

--- a/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Should/DownloadFileReferenceShould.cs
+++ b/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Should/DownloadFileReferenceShould.cs
@@ -18,7 +18,7 @@ namespace AzureStorageWrapper.Tests.Should
         {
             var command = new DownloadBlobReference()
             {
-                Uri = Uris.ExistingFilewithManyDots,
+                Uri = Uris.ExistingFileWithManyDots,
                 ExpiresIn = 360,
             };
 
@@ -34,7 +34,7 @@ namespace AzureStorageWrapper.Tests.Should
         {
             var command = new DownloadBlobReference()
             {
-                Uri = Uris.ExistingFilewithManyExtensions,
+                Uri = Uris.ExistingFileWithManyExtensions,
                 ExpiresIn = 360,
             };
 
@@ -83,7 +83,7 @@ namespace AzureStorageWrapper.Tests.Should
         {
             var command = new DownloadBlobReference()
             {
-                Uri = Uris.UnexistingFile,
+                Uri = Uris.UnExistingFile,
                 ExpiresIn = 360,
             };
 

--- a/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Should/DownloadFileUriVariationsShould.cs
+++ b/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Should/DownloadFileUriVariationsShould.cs
@@ -4,18 +4,18 @@ using Xunit;
 
 namespace AzureStorageWrapper.Tests.Should
 {
-    public class DownloadFileUriVariations : BaseShould
+    public class DownloadFileUriVariationsShould : BaseShould
     {
         private readonly IAzureStorageWrapper _azureStorageWrapper;
 
-        public DownloadFileUriVariations(IAzureStorageWrapper azureStorageWrapper)
+        public DownloadFileUriVariationsShould(IAzureStorageWrapper azureStorageWrapper)
         {
             _azureStorageWrapper = azureStorageWrapper;
         }
 
 
         [Fact]
-        public async Task DownloadFileWithEncodedFileName_ShouldDownloadFileReference()
+        public async Task DownloadFile_WithEncodedFileName_ShouldDownloadFileReference()
         {
             var command = new DownloadBlobReference()
             {
@@ -29,7 +29,7 @@ namespace AzureStorageWrapper.Tests.Should
         }
 
         [Fact]
-        public async Task DownloadFileWithBlanksFileName_ShouldDownloadFileReference()
+        public async Task DownloadFile_WithBlanksFileName_ShouldDownloadFileReference()
         {
             var command = new DownloadBlobReference()
             {

--- a/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Should/UploadBase64ImageShould.cs
+++ b/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Should/UploadBase64ImageShould.cs
@@ -1,0 +1,59 @@
+﻿using AzureStorageWrapper.Commands;
+using AzureStorageWrapper.Tests.Sources;
+using Xunit;
+
+namespace AzureStorageWrapper.Tests.Should
+{
+    public class UploadBase64ImageShould : BaseShould
+    {
+        private readonly IAzureStorageWrapper _azureStorageWrapper;
+
+        public UploadBase64ImageShould(IAzureStorageWrapper azureStorageWrapper)
+        {
+            _azureStorageWrapper = azureStorageWrapper;
+        }
+
+        [Fact]
+        public async Task UploadBase64ImageWithoutHeader_ShouldUploadFile()
+        {
+            var command = new UploadBase64()
+            {
+                Base64 = Images.ImageWithoutEmbeddedTag,
+                Container = "files",
+                Name = "icon",
+                Extension = "png",
+            };
+
+            var response = await _azureStorageWrapper.UploadBlobAsync(command);
+
+            Assert.NotNull(response);
+
+            Assert.True(await PingAsync(response.SasUri));
+        }
+
+
+        /// <summary>
+        /// data:image/png;base64,iVBO....
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task UploadBase64ImageWithHeader_ShouldUploadFile()
+        {
+            var command = new UploadBase64()
+            {
+                Base64 = Images.ImageWithEmbeddedTag, 
+                Container = "files",
+                Name = "icon",
+                Extension = "png",
+            };
+
+            var response = await _azureStorageWrapper.UploadBlobAsync(command);
+
+            Assert.NotNull(response);
+
+            Assert.True(await PingAsync(response.SasUri));
+        }
+
+
+    }
+}

--- a/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Should/UploadBase64Should.cs
+++ b/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Should/UploadBase64Should.cs
@@ -1,6 +1,4 @@
 ﻿using AzureStorageWrapper.Commands;
-using System.Buffers.Text;
-using AzureStorageWrapper.Tests.Sources;
 using Xunit;
 
 namespace AzureStorageWrapper.Tests.Should
@@ -13,50 +11,7 @@ namespace AzureStorageWrapper.Tests.Should
         {
             _azureStorageWrapper = azureStorageWrapper;
         }
-
-        [Fact]
-        public async Task UploadBase64ImageWithoutHeader_ShouldUploadFile()
-        {
-            var command = new UploadBase64()
-            {
-                Base64 = Images.ImageWithoutEmbeddedTag,
-                Container = "files",
-                Name = "icon",
-                Extension = "png",
-            };
-
-            var response = await _azureStorageWrapper.UploadBlobAsync(command);
-
-            Assert.NotNull(response);
-
-            Assert.True(await PingAsync(response.SasUri));
-        }
-
-
-        /// <summary>
-        /// data:image/png;base64,iVBO....
-        /// </summary>
-        /// <returns></returns>
-        [Fact]
-        public async Task UploadBase64ImageWithHeader_ShouldUploadFile()
-        {
-            var command = new UploadBase64()
-            {
-                Base64 = Images.ImageWithEmbeddedTag, 
-                Container = "files",
-                Name = "icon",
-                Extension = "png",
-            };
-
-            var response = await _azureStorageWrapper.UploadBlobAsync(command);
-
-            Assert.NotNull(response);
-
-            Assert.True(await PingAsync(response.SasUri));
-        }
-
-
-
+        
         [Fact]
         public async Task UploadEmptyBase64_ShouldThrowException()
         {

--- a/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Should/UploadFileWithNameVariations.cs
+++ b/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Should/UploadFileWithNameVariations.cs
@@ -1,5 +1,4 @@
 ﻿using AzureStorageWrapper.Commands;
-using System.Buffers.Text;
 using Xunit;
 
 namespace AzureStorageWrapper.Tests.Should

--- a/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Should/UploadInVirtualFolderShould.cs
+++ b/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Should/UploadInVirtualFolderShould.cs
@@ -1,0 +1,86 @@
+﻿using AzureStorageWrapper.Commands;
+using Xunit;
+
+namespace AzureStorageWrapper.Tests.Should
+{
+    public class UploadInVirtualFolderShould : BaseShould
+    {
+        private readonly IAzureStorageWrapper _azureStorageWrapper;
+
+        public UploadInVirtualFolderShould(IAzureStorageWrapper azureStorageWrapper)
+        {
+            _azureStorageWrapper = azureStorageWrapper;
+        }
+
+        [Fact]
+        public async Task UploadFileInContainer_ShouldUploadFile()
+        {
+            var base64 = "SGVsbG8g8J+Zgg==";
+        
+            var command = new UploadBase64()
+            {
+                Base64 = base64,
+                Container = "files",
+                Name = "hello",
+                Extension = "md",
+                UseVirtualFolder = false,
+                Metadata = new Dictionary<string, string>()
+                {
+                    { "UseVirtualFolder", "false" }
+                }
+            };
+
+            var response = await _azureStorageWrapper.UploadBlobAsync(command);
+        
+            Assert.True(await PingAsync(response.SasUri));
+            Assert.Contains("files/hello.md", response.Uri);
+        }
+    
+        [Fact]
+        public async Task UploadFileInVirtualFolder_ShouldUploadFile()
+        {
+            var base64 = "SGVsbG8g8J+Zgg==";
+        
+            var command = new UploadBase64()
+            {
+                Base64 = base64,
+                Container = "files",
+                Name = "hello",
+                Extension = "md",
+                UseVirtualFolder = true,
+                Metadata = new Dictionary<string, string>()
+                {
+                    { "UseVirtualFolder", "true" }
+                }
+            };
+
+            var response = await _azureStorageWrapper.UploadBlobAsync(command);
+        
+            Assert.True(await PingAsync(response.SasUri));
+            Assert.DoesNotContain("files/hello.md", response.Uri);
+        }
+    
+        [Fact]
+        public async Task UploadFile_WithoutSettingUseVirtualFolderProperty_ShouldUploadFile()
+        {
+            var base64 = "SGVsbG8g8J+Zgg==";
+        
+            var command = new UploadBase64()
+            {
+                Base64 = base64,
+                Container = "files",
+                Name = "hello",
+                Extension = "md",
+                Metadata = new Dictionary<string, string>()
+                {
+                    { "UseVirtualFolder", "not set in command" }
+                }
+            };
+
+            var response = await _azureStorageWrapper.UploadBlobAsync(command);
+        
+            Assert.True(await PingAsync(response.SasUri));
+            Assert.DoesNotContain("files/hello.md", response.Uri);
+        }
+    }
+}

--- a/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Should/UriShould.cs
+++ b/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Should/UriShould.cs
@@ -1,0 +1,81 @@
+﻿using Xunit;
+
+namespace AzureStorageWrapper.Tests.Should
+{
+    public class UriShould : BaseShould
+    {
+        private readonly IUriService _uriService;
+
+        private string UriWithVirtualFolder = $"https://accountname.blob.core.windows.net/container/virtualFolder/file.extension";
+        private string UriWithoutVirtualFolder = $"https://accountname.blob.core.windows.net/container/file.extension";
+        public UriShould(IUriService uriService)
+        {
+            _uriService = uriService;
+        }
+
+
+        [Fact]
+        public void GetHost_WithVirtualFolder_ShouldReturnHost()
+        {
+            var host = _uriService.GetHost(UriWithVirtualFolder);
+        
+            Assert.Equal("https://accountname.blob.core.windows.net", host);
+        }
+    
+        [Fact]
+        public void GetHost_WithoutVirtualFolder_ShouldReturnHost()
+        {
+            var host = _uriService.GetHost(UriWithoutVirtualFolder);
+        
+            Assert.Equal("https://accountname.blob.core.windows.net", host);
+        }
+    
+        [Fact]
+        public void GetContainer_WithVirtualFolder_ShouldReturnHost()
+        {
+            var container = _uriService.GetContainer(UriWithVirtualFolder);
+        
+            Assert.Equal("container", container);
+        }
+    
+        [Fact]
+        public void GetContainer_WithoutVirtualFolder_ShouldReturnHost()
+        {
+            var container = _uriService.GetContainer(UriWithoutVirtualFolder);
+        
+            Assert.Equal("container", container);
+        }
+    
+        [Fact]
+        public void GetFileName_WithVirtualFolder_ShouldReturnHost()
+        {
+            var fileName = _uriService.GetFileName(UriWithVirtualFolder);
+        
+            Assert.Equal("file", fileName);
+        }
+    
+        [Fact]
+        public void GetFileName_WithoutVirtualFolder_ShouldReturnHost()
+        {
+            var fileName = _uriService.GetFileName(UriWithoutVirtualFolder);
+        
+            Assert.Equal("file", fileName);
+        }
+    
+        [Fact]
+        public void GetFileExtension_WithVirtualFolder_ShouldReturnHost()
+        {
+            var fileExtension = _uriService.GetFileExtension(UriWithVirtualFolder);
+        
+            Assert.Equal("extension", fileExtension);
+        }
+    
+        [Fact]
+        public void GetFileExtension_WithoutVirtualFolder_ShouldReturnHost()
+        {
+            var fileExtension = _uriService.GetFileExtension(UriWithoutVirtualFolder);
+        
+            Assert.Equal("extension", fileExtension);
+        }
+    }
+}

--- a/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Sources/Uris.cs
+++ b/src/AzureStorageWrapper/AzureStorageWrapper.Tests/Sources/Uris.cs
@@ -2,12 +2,16 @@
 {
     public static class Uris
     {
-        public static string ExistingFile = "https://stgazstgwrapper001westeu.blob.core.windows.net/static-files/hello.md";
-        public static string ExistingFilewithManyDots = "https://stgazstgwrapper001westeu.blob.core.windows.net/static-files/hello.hello.hello.hello.md";
-        public static string ExistingFilewithManyExtensions = "https://stgazstgwrapper001westeu.blob.core.windows.net/static-files/hello.md.md";
-        public static string UnexistingFile = "https://stgazstgwrapper001westeu.blob.core.windows.net/static-files/unexisting-hello.md";
+        public const string ExistingFile = "https://stgazstgwrapper001westeu.blob.core.windows.net/static/hello.md";
 
-        public static string ExistingFileWithBlanks = "https://stgazstgwrapper001westeu.blob.core.windows.net/static-files/hello world.md";
-        public static string ExistingFileWithUriEncoded = "https://stgazstgwrapper001westeu.blob.core.windows.net/static-files/hello%20world.md";
+        public const string ExistingFileWithManyDots = "https://stgazstgwrapper001westeu.blob.core.windows.net/static/hello.hello.hello.hello.md";
+
+        public const string ExistingFileWithManyExtensions = "https://stgazstgwrapper001westeu.blob.core.windows.net/static/hello.md.md";
+
+        public const string UnExistingFile = "https://stgazstgwrapper001westeu.blob.core.windows.net/static/unexisting-hello.md";
+
+        public const string ExistingFileWithBlanks = "https://stgazstgwrapper001westeu.blob.core.windows.net/static/hello hello.md";
+
+        public const string ExistingFileWithUriEncoded = "https://stgazstgwrapper001westeu.blob.core.windows.net/static/hello%20hello.md";
     }
 }

--- a/src/AzureStorageWrapper/AzureStorageWrapper/AzureStorageWrapper.csproj
+++ b/src/AzureStorageWrapper/AzureStorageWrapper/AzureStorageWrapper.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<Nullable>enable</Nullable>
-		<version>2.2.5</version>
+		<version>2.2.6</version>
 		<Title>AzureStorageWrapper</Title>
 		<Authors>Sergio Barriel</Authors>
 		<Description>Wrapper for Azure Storage, aimed at simplifying the file upload process and obtaining links for downloading them.</Description>
@@ -16,7 +16,8 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<IncludeSymbols>False</IncludeSymbols>
-		<PackageReleaseNotes></PackageReleaseNotes>
+		<PackageReleaseNotes>- add virtual folder support
+- add tests</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/AzureStorageWrapper/AzureStorageWrapper/AzureStorageWrapperBase.cs
+++ b/src/AzureStorageWrapper/AzureStorageWrapper/AzureStorageWrapperBase.cs
@@ -54,7 +54,7 @@ namespace AzureStorageWrapper
         /// <summary>
         /// ~2 centuries of work are needed in order to have a 1% probability of at least one collision: https://alex7kom.github.io/nano-nanoid-cc
         /// </summary>
-        internal string GenerateId()
+        internal string RandomString()
         {
             var guid = Guid.NewGuid().ToString("N");
 

--- a/src/AzureStorageWrapper/AzureStorageWrapper/Commands/GetSasUri.cs
+++ b/src/AzureStorageWrapper/AzureStorageWrapper/Commands/GetSasUri.cs
@@ -2,13 +2,7 @@
 {
     public class GetSasUri
     {
-        //public string Folder { get; set; }
-        //public string Name { get; set; }
-        //public string Extension { get; set; }
-        //public string Container { get; set; }
         public string Uri { get; set; }
         public int ExpiresIn { get; set; }
-
-        //public string GeneratePath() => $"{Folder}/{Name}.{Extension}";
     }
 }

--- a/src/AzureStorageWrapper/AzureStorageWrapper/Commands/UploadBase64.cs
+++ b/src/AzureStorageWrapper/AzureStorageWrapper/Commands/UploadBase64.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Buffers.Text;
 using System.IO;
 using System.Text.RegularExpressions;
 

--- a/src/AzureStorageWrapper/AzureStorageWrapper/Commands/UploadBlob.cs
+++ b/src/AzureStorageWrapper/AzureStorageWrapper/Commands/UploadBlob.cs
@@ -8,13 +8,16 @@ namespace AzureStorageWrapper.Commands
         protected UploadBlob()
         {
             Metadata = new Dictionary<string, string>();
+            UseVirtualFolder = true;
         }
 
         public string Name { get; set; }
         public string Extension { get; set; }
         public string Container { get; set; }
-
+        
         public Dictionary<string, string> Metadata { get; set; }
+
+        public bool UseVirtualFolder { get; set; }
 
         public abstract Stream GetContent();
     }

--- a/src/AzureStorageWrapper/AzureStorageWrapper/DependencyInjectionExtension.cs
+++ b/src/AzureStorageWrapper/AzureStorageWrapper/DependencyInjectionExtension.cs
@@ -8,9 +8,11 @@ namespace AzureStorageWrapper
         public static void AddAzureStorageWrapper(this IServiceCollection serviceCollection, AzureStorageWrapperConfiguration configuration)
         {
             //configuration.Validate();
+            
+            serviceCollection.AddSingleton<IUriService, UriService>();
 
             serviceCollection.AddSingleton(configuration);
-
+            
             serviceCollection.AddSingleton<IAzureStorageWrapper, AzureStorageWrapper>();
         }
 
@@ -22,8 +24,10 @@ namespace AzureStorageWrapper
             
             //configuration.Validate();
 
-            serviceCollection.AddSingleton(configuration);
+            serviceCollection.AddSingleton<IUriService, UriService>();
 
+            serviceCollection.AddSingleton(configuration);
+            
             serviceCollection.AddSingleton<IAzureStorageWrapper, AzureStorageWrapper>();
         }
     }

--- a/src/AzureStorageWrapper/AzureStorageWrapper/IUriService.cs
+++ b/src/AzureStorageWrapper/AzureStorageWrapper/IUriService.cs
@@ -1,0 +1,10 @@
+﻿namespace AzureStorageWrapper
+{
+    public interface IUriService
+    {
+        string GetHost(string uri);
+        string GetContainer(string uri);
+        string GetFileName(string uri);
+        string GetFileExtension(string uri);
+    }
+}

--- a/src/AzureStorageWrapper/AzureStorageWrapper/UriService.cs
+++ b/src/AzureStorageWrapper/AzureStorageWrapper/UriService.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.IO;
+
+namespace AzureStorageWrapper
+{
+    public class UriService : IUriService
+    {
+        public UriService() { }
+        
+        public string GetHost(string uri)
+        {
+            var uriObject = new Uri(uri);
+
+            return $"{uriObject.Scheme}://{uriObject.Authority}";
+        }
+
+        public string GetContainer(string uri)
+        {
+            var uriObject = new Uri(uri);
+
+            return uriObject.Segments[1].TrimEnd('/');
+        }
+
+        public string GetFileName(string uri)
+        {
+            var uriObject = new Uri(uri);
+
+            return Path.GetFileNameWithoutExtension(uriObject.LocalPath);
+        }
+        
+        public string GetFileExtension(string uri)
+        {
+            var uriObject = new Uri(uri);
+
+            return Path.GetExtension(uriObject.LocalPath).TrimStart('.');
+        }
+
+    }
+}


### PR DESCRIPTION
By adding **virtual folder** support, a developer can use the property `UserVirtualFolder` in the upload command and disable the use of virtual folders.